### PR TITLE
Update word trimming logic

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -52,8 +52,8 @@ for (const node of allTextNodes) {
     span.textContent = word;
     fragment.appendChild(span);
     fragment.appendChild(document.createTextNode(" "));
-    
-    const trimmedWord = word.replace(/['",.]/, '');
+
+    const trimmedWord = word.replace(/['",.:]/g, '');
 
     const lword = trimmedWord.toLowerCase();
     const stem = word2stem[lword];


### PR DESCRIPTION
* Trim colon (`:`). (e.g. `present:`)
* Remove all double quotes (`"`) and other ASCII symbols in the word. (e.g. `"range"`)

## ScreenShot

### Colon (`:`)

<img width="120" alt="スクリーンショット 2021-05-01 11 39 12" src="https://user-images.githubusercontent.com/6882878/116768501-0a41a500-aa72-11eb-9450-a489080d06b6.png">

### Double Quotes (`"`)

<img width="98" alt="スクリーンショット 2021-05-01 11 38 48" src="https://user-images.githubusercontent.com/6882878/116768527-27767380-aa72-11eb-8ea2-a086bbaf81ca.png">
