### PR TITLE
Update tooltip style

### DIFF
--- a/docs/dictionary.css
+++ b/docs/dictionary.css
@@ -1,6 +1,5 @@
 .word {
   position: relative;
-  cursor: default;
 }
 
 .word:hover {
@@ -10,14 +9,13 @@
 .word-translation {
   display: none;
   position: absolute;
-  top: -3.0rem;
+  top: -1.8rem;
   left: 0;
   color: #3e4042;
   background-color: #f8f8f8;
   border: 1px solid #eee;
   font-size: 0.8rem;
-  padding: 0.5rem;
-  margin: 0.5rem;
+  padding: 0.3rem;
   font-style: normal;
   word-break: keep-all;
   white-space: nowrap;


### PR DESCRIPTION
* 位置を単語の左に揃えて真上にしました
* カーソルを素の設定にしました

<img width="217" alt="スクリーンショット 2021-05-03 16 54 23" src="https://user-images.githubusercontent.com/6882878/116853340-d82a7180-ac30-11eb-91f7-2c48369312ba.png">
<img width="220" alt="スクリーンショット 2021-05-03 16 54 29" src="https://user-images.githubusercontent.com/6882878/116853346-d9f43500-ac30-11eb-9a31-6e290452e663.png">
