### PR TITLE
Add Table of contents

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1,5 +1,6 @@
 window.onload = () => {
     console.log('window loaded');
+    generateTableOfContents();
     main();
 };
 
@@ -12,6 +13,62 @@ function main() {
     }
     processNode(node);
   }
+}
+
+function generateTableOfContents() {
+  // get table of contents
+  const container = document.querySelector(".container");
+  const headers = Array.from(container.querySelectorAll("h2, h3")).filter(
+    (node) => node.id !== ""
+  );
+  const tocItems = headers.map((node) => ({
+    name: node.textContent,
+    id: node.id,
+    isMainHeader: node.nodeName === "H2", // H2 or H3 -> dt or dd
+  }));
+
+  // prepare DOM elements
+  const table = document.createElement("table");
+  table.className = "unruled";
+  const tbody = document.createElement("tbody");
+  table.appendChild(tbody);
+  const tr = document.createElement("tr");
+  tbody.appendChild(tr);
+  const firstTD = document.createElement("td");
+  firstTD.className = "first";
+  tr.appendChild(firstTD);
+  const firstDL = document.createElement("dl");
+  firstTD.appendChild(firstDL);
+  const secondTD = document.createElement("td");
+  tr.appendChild(secondTD);
+  const secondDL = document.createElement("dl");
+  secondTD.appendChild(secondDL);
+
+  // generate table of contents nodes
+  const splitIndex = tocItems.length / 2 + 1;
+  tocItems.forEach((tocItem, i) => {
+    let headerNode;
+    if (tocItem.isMainHeader) {
+      headerNode = document.createElement("dt");
+    } else {
+      headerNode = document.createElement("dd");
+      headerNode.className = "indent";
+    }
+
+    const link = document.createElement("a");
+    link.href = tocItem.id;
+    link.textContent = tocItem.name;
+    headerNode.appendChild(link);
+
+    if (i < splitIndex) {
+      firstDL.appendChild(headerNode);
+      return;
+    }
+    secondDL.appendChild(headerNode);
+  });
+
+  const nav = document.getElementById("nav");
+  nav.appendChild(table);
 }
 
 function collectTextNodes() {

--- a/docs/main.js
+++ b/docs/main.js
@@ -56,7 +56,7 @@ function generateTableOfContents() {
     }
 
     const link = document.createElement("a");
-    link.href = tocItem.id;
+    link.href = `#${tocItem.id}`;
     link.textContent = tocItem.name;
     headerNode.appendChild(link);
 


### PR DESCRIPTION
* This adds `Table of contents` in the same format as https://golang.org/ref/spec .
* Referenced implementation
  - https://github.com/golang/website/blob/3993074e0002181c1c0964610b14e886c7eb4163/_content/lib/godoc/godocs.js#L27

## ScreenShot

<img width="794" alt="スクリーンショット 2021-07-23 0 15 43" src="https://user-images.githubusercontent.com/6882878/126664524-9f3f30af-66fc-4a5a-91ba-be1e7d884bad.png">
