### PR TITLE
Be independent from the parent repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.log
+/spec_orig.html
+/spec_noscript.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# force GNU sed
+ifeq ($(shell uname),Linux)
+	# for Linux
+	SED := sed
+else
+	# for MacOS assuming GNU sed is installed as "gsed"
+	SED := gsed
+endif
+
+all: docs/spec.html docs/dic.ja.js docs/word2lemma.js
+
+.PHONY: spec_orig.html
+spec_orig.html:
+	wget -O spec_orig.html 'https://tip.golang.org/ref/spec'
+
+docs/spec.html: spec_orig.html
+	perl -p -e 'BEGIN{undef $$/;}  s|<script\s*>[^<]*</script>||smg' $< > spec_noscript.html
+	cat spec_noscript.html | $(SED) '6 a <link type="text/css" rel="stylesheet" href="dictionary.css"><script src="word2lemma.js"></script><script src="dic.ja.js"></script><script src="main.js"></script><script src="toc.js"></script>' > $@
+	perl -pi -e 's#/css/#css/#g' $@
+	perl -pi -e 's#/images/#images/#g' $@
+	perl -pi -e 'BEGIN{undef $$/;}  s|(<h1>\s+The)|$$1 <span id="word-wise">Word Wise</span>|' $@
+	perl -pi -e 's|<title>.*</title>|<title>Word Wise Go Spec</title>|' $@
+	perl -pi -e 's|(<main)|$$1 ontouchstart |' $@
+
+docs/dic.ja.js: docs/dic.ja.json
+	echo 'var dic = ' > $@
+	cat $< >> $@
+
+docs/word2lemma.js: docs/word2lemma.json
+	echo 'var word2lemma = ' > $@
+	cat $< >> $@
+

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ The format, file names and contents of data are experimental and maybe be change
 
 ## How to contribute to the dictionary data
 
-Please send me an edit request from this sheet.
-https://docs.google.com/spreadsheets/d/1xme7bN2zgZG1pOOIn4b724L0S3LAuq8IjzWt0d-F8wI/edit#gid=406497718
+Please edit the dictionary file [docs/dic.ja.js](docs/dic.ja.js)
 
 # LICENSE
 


### PR DESCRIPTION
Now the word wise go spec app can be built without the help of https://github.com/DQNEO/gospec-analyzer.

From now on,  `docs/dic.ja.json` should be edited manually.

The only remaining issue is `docs/word2lemma.json` , which is still generated by he analyzer.